### PR TITLE
 Fix README.md: Update Issue URL with Correct Owner (@tscircuit)

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,4 +108,4 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 
 ## Support
 
-If you encounter any issues or have questions, please file an issue on the [GitHub repository](https://github.com/yourusername/kicad-converter/issues).
+If you encounter any issues or have questions, please file an issue on the [GitHub repository](https://github.com/tscircuit/kicad-converter/issues).


### PR DESCRIPTION
### **Description:**

This PR updates the GitHub Issues link in the README.md to point to the correct repository owner (@tscircuit), instead of the placeholder `yourusername`.

**Change:**

* Replaced:
  `https://github.com/yourusername/kicad-converter/issues`
  with
  `https://github.com/tscircuit/kicad-converter/issues`

---

#### ✅ Motivation:

Ensures users can easily file issues in the right repository.

#### ✅ Impact:

Documentation-only change, no code modifications.
