### PR TITLE
Export kicad-sch parser from package entry point

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,2 +1,3 @@
 export * from "./kicad-pcb/index"
 export * from "./kicad-pro/index"
+export * from "./kicad-sch/index"


### PR DESCRIPTION
Hi @seveibar , the parseKicadSch is documented as an API for this package, but I can't access it. It seems it's missing from the export.

Perhaps this is intended? But I'd like to use this for my own project (as a lib).

Short summary:
- `parseKicadSch` and related types were implemented in `lib/kicad-sch/` and tested in `tests/kicad-sch/`, but the module was never re-exported from `lib/index.ts`
- As a result, `parseKicadSch` is absent from the published package bundle despite being documented/advertised as a public API
- Fix: add `export * from "./kicad-sch/index"` to `lib/index.ts`