### PR TITLE
fix: support 'custom' and 'connect' pad types from KiCad 7+

### DIFF
--- a/lib/kicad-pcb/convert-kicad-pcb-to-circuit-json.ts
+++ b/lib/kicad-pcb/convert-kicad-pcb-to-circuit-json.ts
@@ -1,7 +1,7 @@
-import type { Footprint, GrRect, KiCadPcb, Pad, Segment, Via } from "./types"
-import * as CJ from "circuit-json"
 import { transformPCBElements } from "@tscircuit/circuit-json-util"
+import * as CJ from "circuit-json"
 import { scale } from "transformation-matrix"
+import type { Footprint, GrRect, KiCadPcb, Pad, Segment, Via } from "./types"
 
 export function convertKiCadPcbToCircuitJson(
   kicadPcb: KiCadPcb,
@@ -176,6 +176,36 @@ function convertPadToPcbPad(
     })
 
     pads.push(pcb_hole)
+  } else if (pad.type === "custom" || pad.type === "connect") {
+    // "custom" pads use free-form primitives to define their shape; treat as SMD
+    // using their bounding box size so the pad is still represented in circuit-json.
+    // "connect" pads are mechanical/non-electrical SMD pads.
+    for (const kicadLayer of pad.layers) {
+      const layer = mapKicadLayerToTscircuitLayer(kicadLayer)
+      if (!layer) continue
+      const pcb_smtpad = CJ.pcb_smtpad.safeParse({
+        type: "pcb_smtpad",
+        pcb_smtpad_id: pad.uuid || generateUniqueId(),
+        shape: "rect",
+        x: position.x,
+        y: position.y,
+        width: pad.size[0],
+        height: pad.size[1],
+        layer: layer,
+        port_hints: [pad.number],
+        pcb_component_id: footprint.uuid || generateUniqueId(),
+        pcb_port_id: pad.uuid || generateUniqueId(),
+      })
+
+      if (pcb_smtpad.success) {
+        pads.push(pcb_smtpad.data)
+      } else {
+        console.warn(
+          `Failed to parse custom pcb_smtpad "${pad.uuid}"`,
+          pcb_smtpad.error,
+        )
+      }
+    }
   }
   return pads
 }

--- a/lib/kicad-pcb/types.ts
+++ b/lib/kicad-pcb/types.ts
@@ -176,9 +176,9 @@ export interface FpText {
 // Pad within a footprint
 export interface Pad {
   number: string
-  type: "np_thru_hole" | "thru_hole" | "smd"
+  type: "np_thru_hole" | "thru_hole" | "smd" | "custom" | "connect"
   drill?: number
-  shape: "rect" | "roundrect" | "oval" | "circle"
+  shape: "rect" | "roundrect" | "oval" | "circle" | "trapezoid" | "polygon"
   at: [number, number]
   size: [number, number]
   layers: string[]

--- a/lib/kicad-pcb/zod.ts
+++ b/lib/kicad-pcb/zod.ts
@@ -147,8 +147,15 @@ export type ZodNetReference = z.infer<typeof NetReferenceSchema>
 // Pad within a footprint
 export const PadSchema = z.object({
   number: z.string(),
-  type: z.enum(["thru_hole", "np_thru_hole", "smd"]),
-  shape: z.enum(["rect", "roundrect", "oval", "circle"]),
+  type: z.enum(["thru_hole", "np_thru_hole", "smd", "custom", "connect"]),
+  shape: z.enum([
+    "rect",
+    "roundrect",
+    "oval",
+    "circle",
+    "trapezoid",
+    "polygon",
+  ]),
   drill: z.number().optional(),
   at: z.tuple([z.number(), z.number()]),
   size: z.tuple([z.number(), z.number()]),

--- a/tests/kicad-pcb/parse-kicad-pcb3-custom-pad.test.ts
+++ b/tests/kicad-pcb/parse-kicad-pcb3-custom-pad.test.ts
@@ -1,0 +1,91 @@
+import { expect, test } from "bun:test"
+import { parseSExpr } from "lib/common/parse-sexpr"
+import { convertKiCadPcbToCircuitJson } from "lib/kicad-pcb/convert-kicad-pcb-to-circuit-json"
+import { parseKiCadPcb } from "lib/kicad-pcb/parse-kicad-pcb-sexpr"
+
+// Minimal KiCad PCB string containing a footprint with a "custom" type pad
+// to verify that the parser and converter handle newer KiCad pad types without
+// throwing a ZodError (regression test for issue #16).
+const kicadPcbWithCustomPad = `
+(kicad_pcb
+  (version 20221018)
+  (generator pcbnew)
+  (generator_version "7.0")
+  (general
+    (thickness 1.6)
+    (legacy_teardrops no)
+  )
+  (paper "A4")
+  (layers
+    (0 "F.Cu" signal)
+    (31 "B.Cu" signal)
+    (32 "B.Adhes" user "B.Adhesive")
+    (33 "F.Adhes" user "F.Adhesive")
+    (34 "B.Paste" user)
+    (35 "F.Paste" user)
+    (36 "B.SilkS" user "B.Silkscreen")
+    (37 "F.SilkS" user "F.Silkscreen")
+    (38 "B.Mask" user)
+    (39 "F.Mask" user)
+    (40 "Dwgs.User" user "User.Drawings")
+    (41 "Cmts.User" user "User.Comments")
+    (42 "Eco1.User" user "User.Eco1")
+    (43 "Eco2.User" user "User.Eco2")
+    (44 "Edge.Cuts" user)
+    (45 "Margin" user)
+    (46 "B.CrtYd" user "B.Courtyard")
+    (47 "F.CrtYd" user "F.Courtyard")
+    (48 "B.Fab" user "B.Fabrication")
+    (49 "F.Fab" user "F.Fabrication")
+    (50 "User.1" user)
+    (51 "User.2" user)
+    (52 "User.3" user)
+    (53 "User.4" user)
+    (54 "User.5" user)
+    (55 "User.6" user)
+    (56 "User.7" user)
+    (57 "User.8" user)
+    (58 "User.9" user)
+  )
+  (setup
+    (pad_to_mask_clearance 0)
+    (allow_soldermask_bridges_in_footprints no)
+    (pcbplotparams
+      (plot_on_all_layers_selection 0x00010fc_ffffffff)
+      (svgprecision 4)
+      (hpglpennumber 1)
+    )
+  )
+  (net 0 "")
+  (net 1 "GND")
+  (footprint "CustomPadTest:TestPad"
+    (layer "F.Cu")
+    (uuid "aaaabbbb-cccc-dddd-eeee-ffffffffffff")
+    (at 100 100)
+    (pad "1" custom rect
+      (at 0 0)
+      (size 1.5 1.5)
+      (layers "F.Cu" "F.Mask")
+      (net 1 "GND")
+      (uuid "11112222-3333-4444-5555-666677778888")
+    )
+  )
+)
+`
+
+test("parse KiCad PCB with custom pad type without ZodError", () => {
+  const sexpr = parseSExpr(kicadPcbWithCustomPad)
+  const kicadPcb = parseKiCadPcb(sexpr)
+
+  expect(kicadPcb.footprints).toHaveLength(1)
+  const pad = kicadPcb.footprints[0].pads?.[0]
+  expect(pad).toBeDefined()
+  expect(pad?.type).toBe("custom")
+
+  // Converting should NOT throw a ZodError
+  const circuitJson = convertKiCadPcbToCircuitJson(kicadPcb)
+
+  // The custom pad should be emitted as a pcb_smtpad
+  const smtpads = circuitJson.filter((el) => el.type === "pcb_smtpad")
+  expect(smtpads.length).toBeGreaterThan(0)
+})


### PR DESCRIPTION
/claim #16

## Summary

Fixes #16 — KiCad 7+ introduced new pad type values (`custom`, `connect`) and shape values (`trapezoid`, `polygon`) that were not in the existing Zod schema, causing a `ZodError` when importing footprints that use them.

Changes:
- `types.ts`: add `"custom" | "connect"` to the `Pad.type` union, and `"trapezoid" | "polygon"` to `Pad.shape`
- `zod.ts`: expand `PadSchema` type and shape enums to match
- `convert-kicad-pcb-to-circuit-json.ts`: handle `custom`/`connect` pads by mapping them to `pcb_smtpad` using their bounding-box size (the cleanest lossless representation; custom pad primitives are not yet modelled in circuit-json)
- Add regression test `parse-kicad-pcb3-custom-pad.test.ts` that parses a minimal PCB with a `custom` pad and verifies no error is thrown and a `pcb_smtpad` is emitted

## Test plan
- [x] New test `parse-kicad-pcb3-custom-pad.test.ts` passes
- [x] Full test suite passes (`bun test` — 8/8)